### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/web1apps/10a96eab-074b-4bde-92b5-86d599d35198/650dfb7b-6c6b-4a2f-a34f-89863dca5d0c/_apis/work/boardbadge/e16a7f73-5d8c-4144-bd1e-ea869654a197)](https://dev.azure.com/web1apps/10a96eab-074b-4bde-92b5-86d599d35198/_boards/board/t/650dfb7b-6c6b-4a2f-a34f-89863dca5d0c/Microsoft.RequirementCategory)
 # web1apps
 Web1Apps


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/web1apps/10a96eab-074b-4bde-92b5-86d599d35198/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.